### PR TITLE
Add two missing includes

### DIFF
--- a/include/nclog.h
+++ b/include/nclog.h
@@ -8,6 +8,7 @@
 #define NCLOG_H
 
 #include <stdarg.h>
+#include <stdio.h>
 #include "ncexternl.h"
 
 #ifndef NCCATCH

--- a/include/ncrc.h
+++ b/include/ncrc.h
@@ -15,6 +15,7 @@ and accessing rc files (e.g. .daprc).
 #include "ncuri.h"
 #include "nclist.h"
 #include "ncbytes.h"
+#include <stdio.h>
 
 /* getenv() keys */
 #define NCRCENVIGNORE "NCRCENV_IGNORE"


### PR DESCRIPTION
Both files use a FILE* somewhere, but miss a include to stdio.h. This was found while cross compiling the library using the rust bindings. Adding these includes fixes the compilation error.

Filled as https://github.com/Unidata/netcdf-c/pull/2991 to upstream